### PR TITLE
Support for Google App Engine in Read Only Mode

### DIFF
--- a/semidbm/compat.py
+++ b/semidbm/compat.py
@@ -15,9 +15,11 @@ except NameError:
     str_type = str
 
 
-DATA_OPEN_FLAGS = os.O_RDWR | os.O_CREAT | os.O_APPEND
+DATA_OPEN_FLAGS = "r+"
+DATA_OPEN_FLAGS_READ = "r"
 if sys.platform.startswith('win'):
     # On windows we need to specify that we should be
     # reading the file as a binary file so it doesn't
     # change any line ending characters.
-    DATA_OPEN_FLAGS = DATA_OPEN_FLAGS | os.O_BINARY
+    DATA_OPEN_FLAGS += "b"
+    DATA_OPEN_FLAGS_READ += "b"


### PR DESCRIPTION
## The Problem
There is often a need on Google App Engine to have a simple read-only database or key value store. This comes up when one wants to store a large dictionary of information which does not need to be updated very often. Examples include timezone data, list of state or country capitals, annual financial information, or any database that only needs to be updated once every few years. 

Storing this information in a python dictionary is an option, but would be memory inefficient, especially if used infrequently. Storing it in the GAE datastore can be complex to maintain. Storing it in the GAE memcache is not acceptable because it is transient.

## The Solution
A simpler solution is to build a database offline, then upload it to GAE, and then access the database on GAE in read only mode. This commit allows a user of `semidbm` to do just that.

## How
Google App Engine runs python in a sandbox, and does not support `os` file descriptor access that is used by `semidbm`. It also does not support opening files for writing, but it does support read only access.

This commit changes those function calls to the standard python `open`, `read`, and `write` functions, which are supported in the GAE sandbox.  Further, if the `semidbm` database is opened in read-only mode, then the appropriate flags are used which work on GAE.

I have run the tests on this PR, and they all pass.