### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,23 +8,23 @@ Overview
 .. image:: https://coveralls.io/repos/jamesls/semidbm/badge.png?branch=master
    :target: https://coveralls.io/r/jamesls/semidbm?branch=master
 
-.. image:: https://pypip.in/version/semidbm/badge.svg
+.. image:: https://img.shields.io/pypi/v/semidbm.svg
     :target: https://pypi.python.org/pypi/semidbm/
     :alt: Latest Version
 
-.. image:: https://pypip.in/py_versions/semidbm/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/semidbm.svg
     :target: https://pypi.python.org/pypi/semidbm/
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/implementation/semidbm/badge.svg
+.. image:: https://img.shields.io/pypi/implementation/semidbm.svg
     :target: https://pypi.python.org/pypi/semidbm/
     :alt: Supported Python implementations
 
-.. image:: https://pypip.in/license/semidbm/badge.svg
+.. image:: https://img.shields.io/pypi/l/semidbm.svg
     :target: https://pypi.python.org/pypi/semidbm/
     :alt: License
 
-.. image:: https://pypip.in/wheel/semidbm/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/semidbm.svg
     :target: https://pypi.python.org/pypi/semidbm/
     :alt: Wheel Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20semidbm))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `semidbm`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.