### PR TITLE
Fix read-only mode

### DIFF
--- a/semidbm/compat.py
+++ b/semidbm/compat.py
@@ -16,8 +16,10 @@ except NameError:
 
 
 DATA_OPEN_FLAGS = os.O_RDWR | os.O_CREAT | os.O_APPEND
+DATA_OPEN_FLAGS_READONLY = os.O_RDONLY
 if sys.platform.startswith('win'):
     # On windows we need to specify that we should be
     # reading the file as a binary file so it doesn't
     # change any line ending characters.
     DATA_OPEN_FLAGS = DATA_OPEN_FLAGS | os.O_BINARY
+    DATA_OPEN_FLAGS_READONLY = DATA_OPEN_FLAGS_READONLY | os.O_BINARY

--- a/semidbm/db.py
+++ b/semidbm/db.py
@@ -20,6 +20,9 @@ _open = compat.file_open
 
 
 class _SemiDBM(object):
+
+    _data_open_flags = compat.DATA_OPEN_FLAGS
+
     """
 
     :param dbdir: The directory containing the dbm files.  If the directory
@@ -46,7 +49,7 @@ class _SemiDBM(object):
     def _load_db(self):
         self._create_db_dir()
         self._index = self._load_index(self._data_filename)
-        self._data_fd = os.open(self._data_filename, compat.DATA_OPEN_FLAGS)
+        self._data_fd = os.open(self._data_filename, self._data_open_flags)
         self._current_offset = os.lseek(self._data_fd, 0, os.SEEK_END)
 
     def _load_index(self, filename):
@@ -231,6 +234,9 @@ class _SemiDBM(object):
 
 
 class _SemiDBMReadOnly(_SemiDBM):
+
+    _data_open_flags = compat.DATA_OPEN_FLAGS_READONLY
+
     def __delitem__(self, key):
         self._method_not_allowed('delitem')
 


### PR DESCRIPTION
In read-only mode, open data file as read-only to avoid crash on read-only filesystems